### PR TITLE
Feature/resize to avoid bottom inset

### DIFF
--- a/lib/floating_draggable_widget.dart
+++ b/lib/floating_draggable_widget.dart
@@ -21,6 +21,7 @@ class FloatingDraggableWidget extends StatefulWidget {
     this.speed,
     this.deleteWidget,
     this.onDeleteWidget,
+    this.bottom,
     this.isDraggable = true,
     this.autoAlign = false,
     this.deleteWidgetAlignment = Alignment.bottomCenter,
@@ -69,6 +70,7 @@ class FloatingDraggableWidget extends StatefulWidget {
   final Widget floatingWidget;
   final double? dy;
   final double? dx;
+  final double? bottom;
   final double? screenHeight;
   final double? screenWidth;
   final double? speed;
@@ -86,6 +88,7 @@ class FloatingDraggableWidget extends StatefulWidget {
   final double isCollidingDeleteWidgetWidth;
   final EdgeInsets? deleteWidgetPadding;
   final BoxDecoration? deleteWidgetDecoration;
+
   /// If the user need disable the resizeToAvoidBottomInset from Scaffold.
   bool resizeToAvoidBottomInset;
 
@@ -236,9 +239,10 @@ class _FloatingDraggableWidgetState extends State<FloatingDraggableWidget>
                       right: widget.dx == null && left == -1 && top == -1
                           ? 20
                           : null,
-                      bottom: widget.dy == null && left == -1 && top == -1
-                          ? 20
-                          : null,
+                      bottom: widget.bottom ??
+                          (widget.dy == null && left == -1 && top == -1
+                              ? 20
+                              : null),
                       duration: Duration(milliseconds: isDragging ? 100 : 700),
 
                       /// setting animation time and animation type

--- a/lib/floating_draggable_widget.dart
+++ b/lib/floating_draggable_widget.dart
@@ -33,7 +33,7 @@ class FloatingDraggableWidget extends StatefulWidget {
     this.isCollidingDeleteWidgetWidth = 70,
     this.deleteWidgetDecoration,
     this.deleteWidgetPadding = const EdgeInsets.only(bottom: 8),
-    this.resizeToAvoidBottomInsetBool = true,
+    this.resizeToAvoidBottomInset = true,
   }) : super(key: key);
 
   /// mainScreenWidget is required and it accept any widget.
@@ -87,7 +87,7 @@ class FloatingDraggableWidget extends StatefulWidget {
   final EdgeInsets? deleteWidgetPadding;
   final BoxDecoration? deleteWidgetDecoration;
   /// If the user need disable the resizeToAvoidBottomInset from Scaffold.
-  bool resizeToAvoidBottomInsetBool;
+  bool resizeToAvoidBottomInset;
 
   @override
   State<FloatingDraggableWidget> createState() =>
@@ -157,7 +157,7 @@ class _FloatingDraggableWidgetState extends State<FloatingDraggableWidget>
     /// top = widget.dy?? MediaQuery.of(context).size.height / 2;
     /// left = widget.dx?? MediaQuery.of(context).size.width / 2;
     return Scaffold(
-      resizeToAvoidBottomInset: widget.resizeToAvoidBottomInsetBool,
+      resizeToAvoidBottomInset: widget.resizeToAvoidBottomInset,
       body: GestureDetector(
         /// if the user touched out side of the widget the tabbed will be false
         onTap: () {

--- a/lib/floating_draggable_widget.dart
+++ b/lib/floating_draggable_widget.dart
@@ -347,7 +347,10 @@ class _FloatingDraggableWidgetState extends State<FloatingDraggableWidget>
 
                         /// the floating widget with size
                         child: isDragging && widget.widgetWhenDragging != null
-                            ? widget.widgetWhenDragging
+                            ? SizedBox(
+                                key: containerKey2,
+                                child: widget.widgetWhenDragging,
+                              )
                             : SizedBox(
                                 key: containerKey2,
                                 width: widget.floatingWidgetWidth,

--- a/lib/floating_draggable_widget.dart
+++ b/lib/floating_draggable_widget.dart
@@ -35,6 +35,8 @@ class FloatingDraggableWidget extends StatefulWidget {
     this.deleteWidgetDecoration,
     this.deleteWidgetPadding = const EdgeInsets.only(bottom: 8),
     this.resizeToAvoidBottomInset = true,
+    this.onDragging,
+    this.widgetWhenDragging,
   }) : super(key: key);
 
   /// mainScreenWidget is required and it accept any widget.
@@ -88,6 +90,12 @@ class FloatingDraggableWidget extends StatefulWidget {
   final double isCollidingDeleteWidgetWidth;
   final EdgeInsets? deleteWidgetPadding;
   final BoxDecoration? deleteWidgetDecoration;
+
+  /// onDragging optionally accepts a function which is used to notify the user when the widget is dragging.
+  final Function(bool)? onDragging;
+
+  /// widgetWhenDragging optionally accepts a widget which is used to show when the widget is dragging.
+  final Widget? widgetWhenDragging;
 
   /// If the user need disable the resizeToAvoidBottomInset from Scaffold.
   bool resizeToAvoidBottomInset;
@@ -178,6 +186,7 @@ class _FloatingDraggableWidgetState extends State<FloatingDraggableWidget>
 
         /// if the user touch of even gesture detector detect any drag gesture out side of the widget the dragging will be false
         onPanStart: (value) {
+          widget.onDragging?.call(true);
           setState(() {
             isTabbed = false;
           });
@@ -295,6 +304,7 @@ class _FloatingDraggableWidgetState extends State<FloatingDraggableWidget>
 
                         /// give a sliding animation
                         onPanEnd: (value) {
+                          widget.onDragging?.call(false);
                           setState(() {
                             if (isTabbed && isDragEnable) {
                               isDragging = false;
@@ -336,12 +346,14 @@ class _FloatingDraggableWidgetState extends State<FloatingDraggableWidget>
                         },
 
                         /// the floating widget with size
-                        child: SizedBox(
-                          key: containerKey2,
-                          width: widget.floatingWidgetWidth,
-                          height: widget.floatingWidgetHeight,
-                          child: widget.floatingWidget,
-                        ),
+                        child: isDragging && widget.widgetWhenDragging != null
+                            ? widget.widgetWhenDragging
+                            : SizedBox(
+                                key: containerKey2,
+                                width: widget.floatingWidgetWidth,
+                                height: widget.floatingWidgetHeight,
+                                child: widget.floatingWidget,
+                              ),
                       ),
                     ),
                   ],

--- a/lib/floating_draggable_widget.dart
+++ b/lib/floating_draggable_widget.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 /// Does not affect the functionality or performance of the particular widget;
 /// Used physics law supported animation to make it more attractive;
 class FloatingDraggableWidget extends StatefulWidget {
-  const FloatingDraggableWidget({
+  FloatingDraggableWidget({
     Key? key,
     required this.mainScreenWidget,
     required this.floatingWidget,
@@ -33,6 +33,7 @@ class FloatingDraggableWidget extends StatefulWidget {
     this.isCollidingDeleteWidgetWidth = 70,
     this.deleteWidgetDecoration,
     this.deleteWidgetPadding = const EdgeInsets.only(bottom: 8),
+    this.resizeToAvoidBottomInsetBool = true,
   }) : super(key: key);
 
   /// mainScreenWidget is required and it accept any widget.
@@ -85,6 +86,8 @@ class FloatingDraggableWidget extends StatefulWidget {
   final double isCollidingDeleteWidgetWidth;
   final EdgeInsets? deleteWidgetPadding;
   final BoxDecoration? deleteWidgetDecoration;
+  /// If the user need disable the resizeToAvoidBottomInset from Scaffold.
+  bool resizeToAvoidBottomInsetBool;
 
   @override
   State<FloatingDraggableWidget> createState() =>
@@ -119,7 +122,6 @@ class _FloatingDraggableWidgetState extends State<FloatingDraggableWidget>
 
   /// If the user requested to remove the floating widget.
   bool isRemoved = false;
-
   bool hasCollision(GlobalKey<State<StatefulWidget>> key1,
       GlobalKey<State<StatefulWidget>> key2) {
     final box1 = key1.currentContext?.findRenderObject() as RenderBox?;
@@ -155,7 +157,7 @@ class _FloatingDraggableWidgetState extends State<FloatingDraggableWidget>
     /// top = widget.dy?? MediaQuery.of(context).size.height / 2;
     /// left = widget.dx?? MediaQuery.of(context).size.width / 2;
     return Scaffold(
-      resizeToAvoidBottomInset: false,
+      resizeToAvoidBottomInset: widget.resizeToAvoidBottomInsetBool,
       body: GestureDetector(
         /// if the user touched out side of the widget the tabbed will be false
         onTap: () {
@@ -363,7 +365,6 @@ class _FloatingDraggableWidgetState extends State<FloatingDraggableWidget>
       if (dy <= 0) {
         currentTop = widget.floatingWidgetHeight;
       } else {
-
         currentTop = dy;
       }
     }

--- a/lib/floating_draggable_widget.dart
+++ b/lib/floating_draggable_widget.dart
@@ -155,6 +155,7 @@ class _FloatingDraggableWidgetState extends State<FloatingDraggableWidget>
     /// top = widget.dy?? MediaQuery.of(context).size.height / 2;
     /// left = widget.dx?? MediaQuery.of(context).size.width / 2;
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       body: GestureDetector(
         /// if the user touched out side of the widget the tabbed will be false
         onTap: () {


### PR DESCRIPTION
Added a plugin param to avoid the inset on scaffold:
The param has the follow doc:

```
If true the [body] and the scaffold's floating widgets should size
themselves to avoid the onscreen keyboard whose height is defined by the
ambient [MediaQuery]'s [MediaQueryData.viewInsets] `bottom` property.
For example, if there is an onscreen keyboard displayed above the
scaffold, the body can be resized to avoid overlapping the keyboard, which
prevents widgets inside the body from being obscured by the keyboard.
Defaults to true.
```