### PR TITLE
add isDragEnable on init state

### DIFF
--- a/lib/floating_draggable_widget.dart
+++ b/lib/floating_draggable_widget.dart
@@ -164,6 +164,7 @@ class _FloatingDraggableWidgetState extends State<FloatingDraggableWidget>
   void initState() {
     top = widget.dy ?? -1;
     left = widget.dx ?? -1;
+    isDragEnable = widget.isDraggable;
     super.initState();
   }
 


### PR DESCRIPTION
This will set the isDragEnable value to directly be set after the initial build, previously it only trigger on didUpdateWidget (when rebuild), cause when i set isDraggable property to false it does not directly update the isDragEnable on the first load, when i reload it does the job. So anyone that wants to set their isDragEnable to false, add this line.